### PR TITLE
Remove 'enforce_www' 'enforce_no_www' options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 3.0.0
+
+* Removed code handling enforce_www, enforce_no_www. This should be handled
+  on the border, and the code in nginx-base* was insecure.
+
 ## Version 2.3.0
 
 * Enable maintenance/503 page from grains in addition to pillar value

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,7 @@
+Version 3.0.0
+----
+
+No changes needed unless enforce_www or enforce_no_www were used.
+
+If they were, then you must ensure that this redirect is instead performed by
+a system in front of these nginx instances. Eg sslloadbalancer-formula

--- a/nginx/map_app.jinja
+++ b/nginx/map_app.jinja
@@ -14,8 +14,6 @@ requires appslug defined in context
         'redirects': [],
         'http_access_rules': [],
         'external_url': 'http://www.example.com',
-        'enforce_www': False,
-        'enforce_no_www': False,
         'is_external': False,
         'client_max_body_size': None,
     },

--- a/nginx/templates/vhost-base-proxy-only.conf
+++ b/nginx/templates/vhost-base-proxy-only.conf
@@ -43,22 +43,6 @@ server {
 {% endblock http_access_rules %}
 
 
-{% block enforce_www %}
-    {% if nginx_app.is_external and nginx_app.enforce_www  %}
-    if ($host !~* ^www\.) {
-        return 302 {{nginx_app.external_url}}$uri;
-    }
-    {% endif %}
-{% endblock enforce_www %}
-
-{% block enforce_no_www %}
-    {% if nginx_app.is_external and nginx_app.enforce_no_www %}
-    if ($host ~* ^www\.) {
-        return 302 {{nginx_app.external_url}}$uri;
-    }
-    {% endif %}
-{% endblock enforce_no_www %}
-
     {% if nginx_app.client_max_body_size %}
     client_max_body_size {{nginx_app.client_max_body_size}};
     {% endif %}

--- a/nginx/templates/vhost-base.conf
+++ b/nginx/templates/vhost-base.conf
@@ -46,21 +46,6 @@ server {
 {% endblock http_access_rules %}
 
 
-{% block enforce_www %}
-    {% if nginx_app.is_external and nginx_app.enforce_www  %}
-    if ($host !~* ^www\.) {
-        return 302 {{nginx_app.external_url}}$uri;
-    }
-    {% endif %}
-{% endblock enforce_www %}
-
-{% block enforce_no_www %}
-    {% if nginx_app.is_external and nginx_app.enforce_no_www %}
-    if ($host ~* ^www\.) {
-        return 302 {{nginx_app.external_url}}$uri;
-    }
-    {% endif %}
-{% endblock enforce_no_www %}
 
     {% if nginx_app.client_max_body_size %}
     client_max_body_size {{nginx_app.client_max_body_size}};


### PR DESCRIPTION
These options were not used in any production sites, as this
redirection is best performed at the border (for example, in
sslloadbalancer-formula).

The redirect method, using $uri, was insecure, allowing header
injection.

With this in mind, less code FTW.
