### PR TITLE
Add auth just for external ip, SSL support, workers increased, bugfixing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Version 3.2.1
+
 * Pin the version of nginx. Can be overwritten in the pillar.
 
 ## Version 3.2.0

--- a/nginx/map.jinja
+++ b/nginx/map.jinja
@@ -1,7 +1,7 @@
 {% set nginx = salt['grains.filter_by']({
     'Ubuntu-14.04': {
         'pkg': 'nginx-full',
-        'version': '1.4.6-1ubuntu3.2',
+        'version': '1.4.6-1ubuntu3.3',
         'port': '80',
         'throttling': {
             'enabled': False,

--- a/nginx/map_app.jinja
+++ b/nginx/map_app.jinja
@@ -10,6 +10,7 @@ requires appslug defined in context
         'port': nginx.port,
         'auth_basic_user_file': '/etc/nginx/htpasswd-'+appslug,
         'auth_basic': False,
+        'auth_ext': False,
         'auth_basic_users': {},
         'redirects': [],
         'http_access_rules': [],

--- a/nginx/templates/include-basic-auth.conf
+++ b/nginx/templates/include-basic-auth.conf
@@ -5,3 +5,24 @@
    auth_basic         "Restricted";
    auth_basic_user_file  {{ nginx_app.auth_basic_user_file }};
 {% endif %}
+
+{% if nginx.auth_ext %}
+
+  satisfy any;
+  set $realm on;
+  if ( $http_x_real_ip ~ "^10\." ) {
+  set $realm off;
+  }
+
+  if ( $http_x_forwarded_for = "" ) {
+  set $realm off;
+  }
+
+  if ( $http_x_forwarded_for ~ "^10\." ) {
+  set $realm off;
+  }
+
+  auth_basic         $realm;
+  auth_basic_user_file  {{ nginx_app.auth_basic_user_file }};
+
+{% endif %}

--- a/nginx/templates/nginx.conf
+++ b/nginx/templates/nginx.conf
@@ -4,7 +4,7 @@
 #   * Official Russian Documentation: http://nginx.org/ru/docs/
 
 user              nginx;
-worker_processes  1;
+worker_processes  2;
 
 error_log  /var/log/nginx/error.log;
 #error_log  /var/log/nginx/error.log  notice;
@@ -14,7 +14,7 @@ error_log  /var/log/nginx/error.log;
 
 
 events {
-    worker_connections  1024;
+    worker_connections  2048;
 }
 
 

--- a/nginx/templates/vhost-base-proxy-only.conf
+++ b/nginx/templates/vhost-base-proxy-only.conf
@@ -7,8 +7,16 @@
 
 {% block server %}
 server {
+{% if nginx.secure %}
+    listen     443 ssl;
+    server_name  {{server_name|default('_')}};
+    ssl on;
+    ssl_certificate      /etc/pki/{{grains['opg_project']}}/{{grains['opg_project']}}.crt;
+    ssl_certificate_key  /etc/pki/{{grains['opg_project']}}/{{grains['opg_project']}}.key;
+{% else %}
     listen     {{nginx_app.port}} {% if is_default is defined and is_default %}default_server{% endif %};
     server_name  {{server_name|default('_')}};
+{% endif %}
 
 {% block logs %}
     rewrite_log  on;

--- a/nginx/templates/vhost-base.conf
+++ b/nginx/templates/vhost-base.conf
@@ -8,7 +8,7 @@
 {% block server %}
 server {
 {% if nginx.secure %}
-    listen     443;
+    listen     443 ssl;
     server_name  {{server_name|default('_')}};
     ssl on;
     ssl_certificate      /etc/pki/{{grains['opg_project']}}/{{grains['opg_project']}}.crt;

--- a/nginx/templates/vhost-base.conf
+++ b/nginx/templates/vhost-base.conf
@@ -7,8 +7,16 @@
 
 {% block server %}
 server {
+{% if nginx.secure %}
+    listen     443;
+    server_name  {{server_name|default('_')}};
+    ssl on;
+    ssl_certificate      /etc/pki/{{grains['opg_project']}}/{{grains['opg_project']}}.crt;
+    ssl_certificate_key  /etc/pki/{{grains['opg_project']}}/{{grains['opg_project']}}.key;
+{% else %}
     listen     {{nginx_app.port}} {% if is_default is defined and is_default %}default_server{% endif %};
     server_name  {{server_name|default('_')}};
+{% endif %}
 
 {% block logs %}
     rewrite_log  on;


### PR DESCRIPTION
I've increased the default workers to run on at least 2 cpu cores.

Not sure how extensively we are using this formula but if we have boxes with less than one core maybe i should move this into the pillars.