### PR TITLE
opgops-938 - nginx installations fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Version 3.2.4
+* opgops-938 - Unpinned the version of nginx.
+
 ## Version 3.2.3
 * Add optional skip_verify with a sensible default (False) set via nginx.pkg_skip_verify.
 

--- a/nginx/map.jinja
+++ b/nginx/map.jinja
@@ -2,7 +2,7 @@
     'Ubuntu-14.04': {
         'pkg': 'nginx-full',
         'pkg_skip_verify': False,
-        'version': '1.4.6-1ubuntu3.2',
+        'version': '',
         'port': '80',
         'throttling': {
             'enabled': False,
@@ -24,7 +24,7 @@
     'Ubuntu-12.04': {
         'pkg': 'nginx-full',
         'pkg_skip_verify': False,
-        'version': '1.4.6-1ubuntu3.precise',
+        'version': '',
         'port': '80',
         'throttling': {
             'enabled': False,
@@ -46,7 +46,7 @@
     'Unknown': {
         'pkg': 'nginx-full',
         'pkg_skip_verify': False,
-        'version': False,
+        'version': '',
         'port': '80',
         'throttling': {
             'enabled': False,


### PR DESCRIPTION
Currently use of this formula is futile as the version currently specified
no longer exists in the Ubuntu repository.

The specific version has been removed and an empty string put in its place,
which should allow the package manager to select the latest version.

If a specific version should be installed, this should be specified in the
pillar file.