### PR TITLE
Updated the nginx.conf template to add optional core parameters in the pillar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Version 3.2.5 (WIP)
+* Added parameter in core section of nginx.conf via pillar
+
 ## Version 3.2.4
 * opgops-938 - Unpinned the version of nginx.
 

--- a/nginx/map.jinja
+++ b/nginx/map.jinja
@@ -19,6 +19,9 @@
         'readable_doc_dir_globs': [],
         'http_core_module_config': {
             'client_max_body_size': '50k',
+        },
+        'core_module_config': {
+            'worker_rlimit_nofile': '4096',
         }
     },
     'Ubuntu-12.04': {
@@ -41,6 +44,9 @@
         'readable_doc_dir_globs': [],
         'http_core_module_config': {
             'client_max_body_size': '50k',
+        },
+        'core_module_config': {
+            'worker_rlimit_nofile': '4096',
         }
     },
     'Unknown': {
@@ -63,6 +69,9 @@
         'readable_doc_dir_globs': [],
         'http_core_module_config': {
             'client_max_body_size': '50k',
+        },
+        'core_module_config': {
+            'worker_rlimit_nofile': '4096',
         }
     }
 }, grain='osfinger', merge=salt['pillar.get']('nginx',{}), default='Unknown') %}

--- a/nginx/templates/nginx.conf
+++ b/nginx/templates/nginx.conf
@@ -3,6 +3,19 @@
 #   * Official English Documentation: http://nginx.org/en/docs/
 #   * Official Russian Documentation: http://nginx.org/ru/docs/
 
+# add any parameter to this section of nginx.conf via the pillar
+# how to: in the pillar create a section
+# nginx:
+#     nginx_core_module_config
+#             anything <value>
+# and the key/value pair will be added to this section
+
+{% for k,v in nginx.core_module_config.iteritems() %}
+  {{ k }} {{ v }};
+{% endfor %}
+
+
+
 user              nginx;
 worker_processes  1;
 


### PR DESCRIPTION
Allows to create key/values pair in the pillar under the key `nginx.nginx_core_module_config` to be added to the core section of nginx.conf