### PR TITLE
Fixed custom log formats ending up double-quoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v3.3.4
+
+Fixes:
+* double-quoted json in custom log formats
+
 ## v3.3.3
 
 Fixes:

--- a/nginx/lib.sls
+++ b/nginx/lib.sls
@@ -44,7 +44,7 @@ htpasswd -bd /etc/nginx/htpasswd-{{appslug}} {{username}} {{password}}:
   #     } 
   #}
 {% macro nginx_custom_log_formats_and_files(log_config) %}
-  {% for format_name, format_json in log_config.get('formats', {}).iteritems() %}log_format {{ format_name }} '{{ format_json }}';
+  {% for format_name, format_json in log_config.get('formats', {}).iteritems() %}log_format {{ format_name }} {{ format_json }};
   {% endfor %}
 
   {% for log_params in log_config.get('access_logs', []) %}access_log {{ log_params.path }} {{ log_params.format }};


### PR DESCRIPTION
and therefore being unparsable when submitted to logstash via beaver