### PR TITLE
Check the nginx config explicitly

### DIFF
--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -39,6 +39,15 @@ nginx:
       - file: /etc/nginx/nginx.conf
       - file: /etc/nginx/conf.d/*.conf
 
+nginx-config-test:
+  cmd.run:
+    - name: 'nginx -t'
+    - watch:
+{% if 0 == salt['cmd.retcode']('test -d /etc/nginx/sites-available') %}
+      - file: /etc/nginx/sites-available/*
+{% endif %}
+      - file: /etc/nginx/conf.d/*.conf
+
 /var/log/nginx:
   file.directory:
     - mode: 2750


### PR DESCRIPTION
Nginx will check it's configuration files before attempting to load them.
If the check fails then nginx carries on with the old config without
terminating. Unfortunately this means that the formula user can be unaware that
the configuration changes they have made are not being used.

This change adds a state that always runs a check on nginx configuration
and returns an error if the config is bad.