### PR TITLE
Makes overriding of init shell script optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## UNRELEASED
 * Remove watch from sites-available
+* Make the change of init script optional, as it breaks in later versions
 
 ## v3.4.0
 * Check the nginx config explicitly

--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -67,9 +67,11 @@ nginx-config-test:
       - service: nginx
 
 
+
+{% if nginx.get('override_init', False) %}
 #
 # Place the startup script under nginx control
-# This allows us to generate UDP start events 
+# This allows us to generate UDP start events
 #
 /etc/init.d/nginx:
   file.managed:
@@ -83,6 +85,7 @@ nginx-config-test:
       - pkg: nginx-deps-netcat-traditional
     - watch_in:
       - service: nginx
+{% endif %}
 
 {% from 'firewall/lib.sls' import firewall_enable with context %}
 {{ firewall_enable('nginx', nginx.port , 'tcp') }}

--- a/nginx/map.jinja
+++ b/nginx/map.jinja
@@ -4,6 +4,7 @@
         'pkg_skip_verify': False,
         'version': '',
         'port': '80',
+        'override_init': False,
         'throttling': {
             'enabled': False,
             'zones': {


### PR DESCRIPTION
Make overriding of init shell script optional as in later versions
this has changed and it breaks. The init modification is only there
to generate udp events/stats which are not even used in the current
stack.